### PR TITLE
Update dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mocha": "1.13.x",
     "chai": "1.8.x",
     "escomplex-ast-moz": "0.1.x",
-    "esprima": "1.0.x"
+    "esprima": "2.6.x"
   },
   "scripts": {
     "lint": "./node_modules/jshint/bin/jshint src --config config/jshint.json",


### PR DESCRIPTION
Originally prompted because the fossilized version of esprima used by escomplex
does not appear to support `for ... in` loops.

```
for(let key in object) {
...
}
```

```
Package      Current  Wanted  Latest  Location
chai           1.8.1   1.8.1   3.2.0  chai
check-types    2.1.1   2.1.1   3.3.1  check-types
jshint        2.1.11  2.1.11   2.8.0  jshint
mocha         1.13.0  1.13.0   2.3.0  mocha
```

All tests pass.