### PR TITLE
Use condition instead of Math.min for major speed boost

### DIFF
--- a/src/project.js
+++ b/src/project.js
@@ -176,7 +176,9 @@ function createVisibilityMatrix (result) {
     for (k = 0; k < matrixLen; k += 1) {
         for (i = 0; i < matrixLen; i += 1) {
             for (j = 0; j < matrixLen; j += 1) {
-                visibilityMatrix[i][j] = Math.min(visibilityMatrix[i][j], visibilityMatrix[i][k] + visibilityMatrix[k][j]);
+                if (visibilityMatrix[i][j] > visibilityMatrix[i][k] + visibilityMatrix[k][j]) {
+                    visibilityMatrix[i][j] = visibilityMatrix[i][k] + visibilityMatrix[k][j];
+                }
             }
         }
     }


### PR DESCRIPTION
We analyse project with more than 1000 files and we noticed, that `createVisibilityMatrix` takes about 120s to run because Floyd-Warshal has complexity O(n^3) and those Math.min calls are slowing it down.

When using condition based approach Floyd-Warshall over matrix with 1000 elements is computed in about 14s.