### PR TITLE
Updated node version targets in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 sudo: false
 node_js:
   - "stable"
+  - "4.4"
+  - "4.3"
+  - "4.2"
   - "0.12"
-  - "0.11"
-  - "0.10"


### PR DESCRIPTION
Remove v0.10 and v0.11 from the travis ci config; added LTS versions