### PR TITLE
Fixed a bug with the cyclomatic complexity of logical AND. Fixed #16

### DIFF
--- a/src/syntax/LogicalExpression.js
+++ b/src/syntax/LogicalExpression.js
@@ -10,7 +10,9 @@ function get (settings) {
     return traits.actualise(
         0,
         function (node) {
-            return settings.logicalor && node.operator === '||' ? 1 : 0;
+            var isAnd = node.operator === '&&';
+            var isOr = node.operator === '||';
+            return (isAnd || (settings.logicalor && isOr)) ? 1 : 0;
         },
         function (node) {
             return node.operator;

--- a/test/module.js
+++ b/test/module.js
@@ -1996,7 +1996,18 @@ suite('module:', function () {
             });
         });
 
-        suite('logical or expression with logicalor false:', function () {
+        suite('logical AND expression:', function () {
+            test('aggregate has correct cyclomatic complexity', function () {
+                var report = escomplex.analyse(
+                    esprima.parse('var foo = true && false;'),
+                    mozWalker,
+                    {}
+                );
+                assert.strictEqual(report.cyclomatic, 2);
+            });
+        });
+
+        suite('logical OR expression with logicalor false:', function () {
             var report;
 
             setup(function () {
@@ -2128,7 +2139,7 @@ suite('module:', function () {
             });
 
             test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
+                assert.strictEqual(report.aggregate.cyclomatic, 3);
             });
 
             test('aggregate has correct Halstead total operators', function () {

--- a/test/walker.js
+++ b/test/walker.js
@@ -220,7 +220,21 @@ suite('AST Walker', function () {
         test('binary expression');
         test('assignment expression');
         test('update expression');
-        test('logical expression');
+
+        test('logical expression: &&', function () {
+            this.walk('1 && 1');
+            var expression = this.callbacks.processNode.firstCall.args[0].expression;
+            assert.strictEqual(expression.type, 'LogicalExpression');
+            assert.strictEqual(expression.operator, '&&');
+        });
+
+        test('logical expression: ||', function () {
+            this.walk('1 || 1');
+            var expression = this.callbacks.processNode.firstCall.args[0].expression;
+            assert.strictEqual(expression.type, 'LogicalExpression');
+            assert.strictEqual(expression.operator, '||');
+        });
+
         test('conditional expression');
         test('call expression');
         test('new expression');


### PR DESCRIPTION
The logical expression syntax parser wasn't taking the logical AND
operator into account. As a result the cyclomatic complexity of "&&" was
miscalculated in the module.js unit tests.

This commit adds logic to increment the cyclomatic complexity given the
presence of logical ANDs as well as update the unit tests to reflect the
intended behavior.